### PR TITLE
feat(github): add bug_report and feature_request issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Something is broken or not working as expected.
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Found a bug? Thanks for reporting it. Fill in as much detail as you can so we can reproduce it quickly.
+        For security vulnerabilities, do **not** file a public issue — see SECURITY.md.
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened?
+      description: A clear description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. See error
+    validations:
+      required: true
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and OS
+      placeholder: "Chrome 125 on macOS 14"
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Screenshots or console logs (optional)
+    validations:
+      required: false
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: This is not a security vulnerability (those go to anay@studymap.dev).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: General question or feedback
+    url: mailto:dhawansanay@gmail.com
+    about: Questions and general feedback — from CONTRIBUTING.md.
+  - name: Security vulnerability
+    url: mailto:anay@studymap.dev
+    about: Report security issues privately — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Suggest a new feature or improvement.
+title: "[feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea to make StudyMap better? A clear problem statement helps us understand the need.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the need or frustration this feature would address.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen? How should it work?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered (optional)
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context (optional)
+      description: Mockups, examples, links, or anything else helpful.
+    validations:
+      required: false
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true


### PR DESCRIPTION
Adds `.github/ISSUE_TEMPLATE/bug_report.yml` and `feature_request.yml` so
contributors have a guided path to file bugs and request features. Adds
`config.yml` to disable blank issues and surface the two maintainer contact
emails from CONTRIBUTING.md and SECURITY.md.

Closes #17

## Type of change

- [ ] New public place(s)
- [ ] New or updated benefit guide
- [ ] New or updated resource link
- [ ] Code or fix
- [x] Docs

## Proof (required for new public places)

N/A — no places added.

## Checklist

- [x] The site hosts no copyrighted files; resource and paper changes are links only.
- [x] No em dashes in any copy.
