### PR TITLE
Update library.json

### DIFF
--- a/data/places/library.json
+++ b/data/places/library.json
@@ -108,5 +108,26 @@
     "address": "Sector 5, Nerul, Navi Mumbai 400706",
     "gmaps_link": "https://maps.google.com/?q=19.0314,73.0246",
     "added_by": "thunderblitzyt-eng"
-  }
+  },{
+  "id": "jakarta-library-01",
+  "name": "Perpustakaan Nasional Republik Indonesia",
+  "type": "library",
+  "city": "jakarta",
+  "lat": -6.1814519,
+  "lng": 106.8269647,
+  "address": "Jl. Medan Merdeka Sel. No.11, Gambir, Jakarta Pusat 10110",
+  "gmaps_link": "https://maps.google.com/?cid=ChIJkwxuWUL0aS4RNv55CeSLpUs",
+  "added_by": "Yojeet(Circout-sudo)"
+},{
+  "id": "depok-library-01",
+  "name": "University of Indonesia Library",
+  "type": "library",
+  "city": "depok",
+  "lat": -6.3652214,
+  "lng": 106.8295695,
+  "address": "Gedung Crystal of Knowledge, Jl. Letjen DR. Sjarif Thajeb, Pondok Cina, Depok, West Java 16424",
+  "gmaps_link": "https://maps.google.com/?cid=ChIJvYVjmBDsaS4Rr9Bc9B5a1VU",
+  "added_by": "Yojeet(Circout-sudo)"
+}
+  
 ]


### PR DESCRIPTION
added two libraries in Jakarta and Depok

## What this changes
The website will now also show two libraries in Indonesia, one in Jakarta and one in Depok.

## Type of change
- [x] New public place(s)

## Proof (required for new public places)

**Perpustakaan Nasional Republik Indonesia**

| Field | Value |
|-------|-------|
| Source or citation | https://maps.app.goo.gl/ohcApuK3yjsmAA5H7 |
| Google Maps rating (must be >= 4.0) | 4.7 |
| Google Maps review count (must be >= 50) | 9,177 |
| Date verified | 26 June 2026 |

**University of Indonesia Library**

| Field | Value |
|-------|-------|
| Source or citation |https://www.google.com/maps/place/University+of+Indonesia+Library/@-6.3652214,106.8269946,17z/data=!3m1!4b1!4m6!3m5!1s0x2e69ec10986385bd:0x55d55a1ef45cd0af!8m2!3d-6.3652214!4d106.8295695!16s%2Fg%2F122vxhvt?entry=ttu&g_ep=EgoyMDI2MDYyNC4wIKXMDSoASAFQAw%3D%3D |
| Google Maps rating (must be >= 4.0) | 4.6 |
| Google Maps review count (must be >= 50) | 1,102 |
| Date verified | 26 June 2026 |

- [x] Each place's rating is 4.0 or higher.
- [x] Each place has 50 or more reviews.
- [x] Coordinates point to the correct entrance.
- [x] The JSON record stops at `gmaps_link` and `added_by` (no proof fields committed).

## Checklist
- [x] The site hosts no copyrighted files; resource and paper changes are links only.
- [x] No em dashes in any copy.