### PR TITLE
refactor(constants): extract MAP_CENTER, DEFAULT_ZOOM, REGION_BOUNDS …

### DIFF
--- a/src/components/map/map-view.tsx
+++ b/src/components/map/map-view.tsx
@@ -15,7 +15,7 @@ import {
 
 import type { Place } from "@/lib/types";
 import type { LatLng } from "@/lib/geo";
-import { MMR_CENTER, MMR_DEFAULT_ZOOM } from "@/lib/places";
+import { MAP_CENTER, DEFAULT_ZOOM } from "@/lib/constants";
 import { PLACE_TYPE_COLORS } from "@/lib/map";
 import { PinPopup } from "@/components/pins/pin-popup";
 
@@ -117,7 +117,7 @@ export default function MapView({
   userLocation,
   focusId,
   interactive = true,
-  zoom = MMR_DEFAULT_ZOOM,
+  zoom = DEFAULT_ZOOM,
 }: MapViewProps) {
   const focusPlace = focusId
     ? places.find((place) => place.id === focusId)
@@ -134,7 +134,7 @@ export default function MapView({
       className="size-full"
     >
     <MapContainer
-      center={MMR_CENTER}
+      center={MAP_CENTER}
       zoom={zoom}
       scrollWheelZoom={false}
       dragging={interactive}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,16 @@
+/** Approximate centre of the Mumbai Metropolitan Region, used as the initial map position. */
+export const MAP_CENTER: [number, number] = [19.08, 72.95];
+
+/** Default zoom level for the MMR map view. */
+export const DEFAULT_ZOOM = 11;
+
+/**
+ * Valid coordinate bounds for the Mumbai Metropolitan Region.
+ * Used for data validation and will anchor the config-driven region work.
+ */
+export const REGION_BOUNDS = {
+  minLat: 18,
+  maxLat: 20,
+  minLng: 72,
+  maxLng: 73,
+} as const;

--- a/src/lib/places.ts
+++ b/src/lib/places.ts
@@ -9,10 +9,6 @@ import library from "../../data/places/library.json";
 import impLocations from "../../data/places/imp_locations.json";
 import trainStation from "../../data/places/train_station.json";
 
-/** Approximate centre of the Mumbai Metropolitan Region, for the initial map view. */
-export const MMR_CENTER: [number, number] = [19.08, 72.95];
-export const MMR_DEFAULT_ZOOM = 11;
-
 const ALL: Place[] = [
   ...(airport as Place[]),
   ...(bookShop as Place[]),


### PR DESCRIPTION
## What this changes

Extracts hardcoded map constants (`MAP_CENTER`, `DEFAULT_ZOOM`, `REGION_BOUNDS`) into a
single `src/lib/constants.ts`. Removes the duplicate definitions from `places.ts` and
updates `map-view.tsx` to import from the new file. Closes #21.

## Type of change

- [ ] New public place(s)
- [ ] New or updated benefit guide
- [ ] New or updated resource link
- [x] Code or fix
- [ ] Docs

## Proof (required for new public places)

N/A - no places added in this PR.

## Checklist

- [x] The site hosts no copyrighted files; resource and paper changes are links only.
- [x] No em dashes in any copy.
