### PR TITLE
fix: reinstall Vercel Web Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "studymap",
-  "version": "2.0.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "studymap",
-      "version": "2.0.0",
+      "version": "2.4.0",
       "dependencies": {
         "@base-ui/react": "^1.5.0",
         "@supabase/ssr": "^0.12.0",
         "@supabase/supabase-js": "^2.108.2",
+        "@vercel/analytics": "^2.0.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "leaflet": "^1.9.4",
@@ -5338,6 +5339,48 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.9",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@base-ui/react": "^1.5.0",
     "@supabase/ssr": "^0.12.0",
     "@supabase/supabase-js": "^2.108.2",
+    "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "leaflet": "^1.9.4",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { Footer } from "@/components/layout/footer";
 import { Toaster } from "@/components/ui/sonner";
 import { PwaRegister } from "@/components/pwa-register";
 import { Analytics } from "@/components/analytics";
+import { Analytics as VercelAnalytics } from "@vercel/analytics/next";
 import { cn } from "@/lib/utils";
 
 export const metadata: Metadata = {
@@ -72,6 +73,7 @@ export default function RootLayout({
           <PwaRegister />
         </ThemeProvider>
         <Analytics />
+        <VercelAnalytics />
       </body>
     </html>
   );


### PR DESCRIPTION
@vercel/analytics was installed via a Vercel bot PR (#91) then reverted 11 minutes later with no stated reason (#93), silently removing the tracking script from the site ever since. Reinstall it the same way: aliased <VercelAnalytics /> alongside the existing Umami <Analytics /> in the root layout.

## What this changes

<!-- One or two lines. Link the issue if there is one. -->

## Type of change

- [ ] New public place(s)
- [ ] New or updated benefit guide
- [ ] New or updated resource link
- [ ] Code or fix
- [ ] Docs

## Proof (required for new public places)

Fill this in for every place added in this PR. It stays in the PR, not in the
dataset.

| Field | Value |
|-------|-------|
| Source or citation | |
| Google Maps rating (must be >= 4.0) | |
| Google Maps review count (must be >= 50) | |
| Date verified | |

- [ ] Each place's rating is 4.0 or higher.
- [ ] Each place has 50 or more reviews.
- [ ] Coordinates point to the correct entrance.
- [ ] The JSON record stops at `gmaps_link` and `added_by` (no proof fields committed).

## Checklist

- [ ] The site hosts no copyrighted files; resource and paper changes are links only.
- [ ] No em dashes in any copy.
