### PR TITLE
fix(map): resolve sidebar density issue, remove zoom hint workaround

### DIFF
--- a/src/components/map/category-chips.tsx
+++ b/src/components/map/category-chips.tsx
@@ -26,7 +26,12 @@ export function CategoryChips({
 }: CategoryChipsProps) {
   return (
     <div
-      className="flex flex-wrap gap-1.5"
+      className={cn(
+        "flex gap-1.5",
+        scroll
+          ? "overflow-x-auto pb-1 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
+          : "flex-wrap",
+      )}
       role="group"
       aria-label="Filter by place type"
     >

--- a/src/components/map/places-map.tsx
+++ b/src/components/map/places-map.tsx
@@ -60,10 +60,6 @@ export function PlacesMap({ places }: PlacesMapProps) {
     SHEET_SNAP_POINTS[0],
   );
   const [sheetOpen, setSheetOpen] = React.useState(false);
-  const [zoomHintVisible, setZoomHintVisible] = React.useState(() => {
-    if (typeof window === "undefined") return false;
-    return localStorage.getItem("studymap:zoom-hint-dismissed") !== "true";
-  });
   const hydrated = React.useRef(false);
 
   const [user, setUser] = React.useState<User | null>(null);
@@ -303,8 +299,8 @@ export function PlacesMap({ places }: PlacesMapProps) {
   return (
     <div className="flex h-full w-full overflow-hidden">
       {/* Desktop sidebar */}
-      <aside className="hidden w-[360px] shrink-0 flex-col border-r border-border bg-card p-4 lg:flex">
-        <MapPanel {...panelProps} showSearch showNearMe />
+      <aside className="hidden w-[360px] shrink-0 flex-col overflow-hidden border-r border-border bg-card p-4 lg:flex">
+        <MapPanel {...panelProps} showSearch showNearMe scrollChips />
       </aside>
 
       {/* Map + mobile overlays */}
@@ -318,24 +314,6 @@ export function PlacesMap({ places }: PlacesMapProps) {
             closePopupTrigger={closePopupTrigger}
           />
         </MapErrorBoundary>
-
-        {/* Desktop zoom hint: dismissible pill, laptop only */}
-        {zoomHintVisible && (
-          <div className="pointer-events-auto absolute left-1/2 top-3 z-[999] hidden -translate-x-1/2 items-center gap-2 rounded-full border border-border bg-card/80 px-3 py-1.5 text-xs text-muted-foreground shadow-sm backdrop-blur-sm lg:flex">
-            <span>Best viewed at 75% browser zoom</span>
-            <button
-              type="button"
-              aria-label="Dismiss hint"
-              className="ml-1 text-muted-foreground hover:text-foreground"
-              onClick={() => {
-                setZoomHintVisible(false);
-                localStorage.setItem("studymap:zoom-hint-dismissed", "true");
-              }}
-            >
-              x
-            </button>
-          </div>
-        )}
 
         {/* Mobile top bar: persistent search + filters trigger */}
         <div className="pointer-events-none absolute inset-x-3 top-3 z-[1000] flex gap-2 lg:hidden">

--- a/src/components/map/results-list.tsx
+++ b/src/components/map/results-list.tsx
@@ -32,7 +32,7 @@ export function ResultsList({
   toggle,
 }: ResultsListProps) {
   return (
-    <div className="flex min-h-0 flex-col">
+    <div className="flex min-h-[120px] flex-1 flex-col">
       <div className="flex items-center justify-between pb-1.5">
         <p className="text-xs font-medium text-muted-foreground">{header}</p>
         {toggle && (


### PR DESCRIPTION
Category chips now use horizontal scroll on desktop (matching mobile) instead of flex-wrap, eliminating multi-row wrapping of long labels like "Foreign lang exam centre". Results list fills remaining sidebar space via flex-1 with a 120px floor, and the desktop aside gains overflow-hidden to keep content bounded. The "Best viewed at 75% browser zoom" pill is removed since the underlying density problem is now resolved.

## What this changes
 
Fix the desktop sidebar density issue that forced users to zoom to 75% to see results. Category chips now scroll horizontally on desktop instead of wrapping, the results list fills remaining sidebar space with a guaranteed minimum height, and the "Best viewed at 75% browser zoom" pill is removed.
 
## Type of change
 
- [ ] New public place(s)
- [ ] New or updated benefit guide
- [ ] New or updated resource link
- [x] Code or fix
- [ ] Docs
 
## Proof (required for new public places)
 
N/A -- no public places added.
 
## Checklist
 
- [x] The site hosts no copyrighted files; resource and paper changes are links only.
- [x] No em dashes in any copy.