### PR TITLE
Add robots.ts

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+import { site } from "@/lib/site";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/auth/", "/login", "/offline"],
+    },
+    sitemap: `${site.url}/sitemap.xml`,
+  };
+}


### PR DESCRIPTION
Closes #119.

## What this changes

Adds `src/app/robots.ts`. `src/app/sitemap.ts` already existed on `main` and covers the static routes, `docsPages`, and `/legal/*`, so only the robots half of the issue was outstanding.

The route allows crawling, points at `${site.url}/sitemap.xml`, and disallows `/auth/`, `/login`, and the PWA `/offline` fallback.

Per-city pages (#127) have not landed yet, so nothing was added for them.

## Type of change

- [ ] New public place(s)
- [ ] New or updated benefit guide
- [ ] New or updated resource link
- [x] Code or fix
- [ ] Docs

## Proof (required for new public places)

N/A, no places added in this PR.

- [x] Each place's rating is 4.0 or higher. - N/A
- [x] Each place has 50 or more reviews. - N/A
- [x] Coordinates point to the correct entrance. - N/A
- [x] The JSON record stops at `gmaps_link` and `added_by` (no proof fields committed). - N/A

## Checklist

- [x] The site hosts no copyrighted files; resource and paper changes are links only.
- [x] No em dashes in any copy.

## Verifying

`npx tsc --noEmit` and `npx eslint src/app/robots.ts` are clean. `npm run build` lists both `/robots.txt` and `/sitemap.xml` as prerendered static routes.

Generated `robots.txt`:

```
User-Agent: *
Allow: /
Disallow: /auth/
Disallow: /login
Disallow: /offline

Sitemap: https://studyymap.com/sitemap.xml
```

Generated `sitemap.xml`: 25 URLs, no duplicates (`sort | uniq -d` empty), nothing under `/auth` or `/login`.
