### PR TITLE
feat(map): make empty and offline states actionable

### DIFF
--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -19,6 +19,21 @@ export default function OfflinePage() {
         Pages you have already opened still work offline, including the map. This
         page just means the one you asked for has not been cached yet.
       </p>
+      <div className="mt-6 grid w-full gap-3 rounded-lg border border-border bg-card p-4 text-left text-sm">
+        <div>
+          <h2 className="font-semibold text-foreground">Available offline</h2>
+          <p className="mt-1 text-muted-foreground">
+            Previously opened pages and cached map data may still be available.
+          </p>
+        </div>
+        <div>
+          <h2 className="font-semibold text-foreground">Needs a connection</h2>
+          <p className="mt-1 text-muted-foreground">
+            Uncached pages, fresh map tiles, sign-in, and live updates need the
+            network.
+          </p>
+        </div>
+      </div>
       <Button asChild className="mt-6">
         <Link href="/">Back to the map</Link>
       </Button>

--- a/src/components/map/map-panel.tsx
+++ b/src/components/map/map-panel.tsx
@@ -48,7 +48,8 @@ interface MapPanelProps {
 
   rows: ResultRow[];
   resultsHeader: string;
-  resultsEmptyHint: string;
+  activeFilters: string[];
+  onResetFilters: () => void;
   resultsToggle?: { label: string; onClick: () => void } | null;
   onSelectPlace: (place: Place) => void;
 
@@ -77,7 +78,8 @@ export function MapPanel({
   resultCount,
   rows,
   resultsHeader,
-  resultsEmptyHint,
+  activeFilters,
+  onResetFilters,
   resultsToggle,
   onSelectPlace,
   onLocated,
@@ -193,7 +195,11 @@ export function MapPanel({
       <ResultsList
         header={resultsHeader}
         rows={rows}
-        emptyHint={resultsEmptyHint}
+        emptyState={{
+          activeFilters,
+          onReset: onResetFilters,
+          onSuggest: () => setSuggestOpen(true),
+        }}
         onSelect={onSelectPlace}
         toggle={resultsToggle}
       />

--- a/src/components/map/places-map.tsx
+++ b/src/components/map/places-map.tsx
@@ -7,7 +7,7 @@ import { ChevronUp, Search, SlidersHorizontal } from "lucide-react";
 import { toast } from "sonner";
 
 import type { Place, PlaceType } from "@/lib/types";
-import { PLACE_TYPES } from "@/lib/types";
+import { humanizeCity, PLACE_TYPES, PLACE_TYPE_LABELS } from "@/lib/types";
 import { cityBounds, filterPlaces, getCities } from "@/lib/places";
 import { placesByDistance, type LatLng } from "@/lib/geo";
 import { buildShareUrl, mapStateToSearch, parseMapState } from "@/lib/share";
@@ -34,7 +34,15 @@ import type { PlaceFilters } from "@/components/map/filters";
 const MapView = dynamic(() => import("@/components/map/map-view"), {
   ssr: false,
   loading: () => (
-    <div className="size-full animate-pulse bg-muted" aria-hidden />
+    <div
+      className="relative size-full animate-pulse bg-muted"
+      role="status"
+      aria-label="Loading map"
+    >
+      <div className="absolute inset-6 rounded-xl border border-border/60 bg-card/30" />
+      <div className="absolute left-1/2 top-1/2 h-8 w-8 -translate-x-1/2 -translate-y-1/2 rounded-full bg-card/60" />
+      <span className="sr-only">Loading map</span>
+    </div>
   ),
 });
 
@@ -74,6 +82,16 @@ export function PlacesMap({ places }: PlacesMapProps) {
   const [lastUserId, setLastUserId] = React.useState<string | null>(null);
 
   const cities = React.useMemo(() => getCities(places), [places]);
+
+  const activeFilters = React.useMemo(() => {
+    const labels: string[] = [];
+    if (filters.types.length > 0) {
+      labels.push(`types: ${filters.types.map((type) => PLACE_TYPE_LABELS[type]).join(", ")}`);
+    }
+    if (filters.city) labels.push(`city: ${humanizeCity(filters.city)}`);
+    if (filters.query.trim()) labels.push(`search: ${filters.query.trim()}`);
+    return labels;
+  }, [filters]);
 
   // Clear stale saved-places/home data as soon as the signed-in user changes,
   // during render rather than an effect, so there's no stale-data flash.
@@ -273,7 +291,8 @@ export function PlacesMap({ places }: PlacesMapProps) {
     resultCount: visible.length,
     rows,
     resultsHeader,
-    resultsEmptyHint: "No places match these filters. Try Reset.",
+    activeFilters,
+    onResetFilters: () => setFilters({ types: [], city: null, query: "" }),
     resultsToggle,
     onSelectPlace: selectPlace,
     onLocated,

--- a/src/components/map/results-list.test.tsx
+++ b/src/components/map/results-list.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ResultsList } from "@/components/map/results-list";
+
+describe("ResultsList empty state", () => {
+  it("describes active filters and offers reset and contribution actions", () => {
+    const onReset = vi.fn();
+    const onSuggest = vi.fn();
+
+    render(
+      <ResultsList
+        header="All places"
+        rows={[]}
+        emptyState={{
+          activeFilters: ["types: Library", "city: Thane"],
+          onReset,
+          onSuggest,
+        }}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("status").textContent).toContain(
+      "No places match types: Library · city: Thane.",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Clear filters" }));
+    fireEvent.click(screen.getByRole("button", { name: "Suggest a place" }));
+
+    expect(onReset).toHaveBeenCalledOnce();
+    expect(onSuggest).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/map/results-list.tsx
+++ b/src/components/map/results-list.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { Navigation } from "lucide-react";
+import { MapPinPlus, Navigation, RotateCcw } from "lucide-react";
 
 import type { Place } from "@/lib/types";
 import { PLACE_TYPE_LABELS } from "@/lib/types";
 import { PLACE_TYPE_COLORS } from "@/lib/map";
 import { directionsUrl } from "@/lib/map";
 import { formatDistance } from "@/lib/geo";
+import { Button } from "@/components/ui/button";
 
 export interface ResultRow {
   place: Place;
@@ -16,8 +17,11 @@ export interface ResultRow {
 interface ResultsListProps {
   header: string;
   rows: ResultRow[];
-  /** Shown when there are no rows (e.g. filters exclude everything). */
-  emptyHint: string;
+  emptyState: {
+    activeFilters: string[];
+    onReset: () => void;
+    onSuggest: () => void;
+  };
   onSelect: (place: Place) => void;
   /** Optional expand/collapse control (e.g. "Show all" for the nearest list). */
   toggle?: { label: string; onClick: () => void } | null;
@@ -27,7 +31,7 @@ interface ResultsListProps {
 export function ResultsList({
   header,
   rows,
-  emptyHint,
+  emptyState,
   onSelect,
   toggle,
 }: ResultsListProps) {
@@ -47,9 +51,33 @@ export function ResultsList({
       </div>
 
       {rows.length === 0 ? (
-        <p className="rounded-md bg-muted/50 px-3 py-4 text-center text-xs text-muted-foreground">
-          {emptyHint}
-        </p>
+        <div
+          role="status"
+          className="rounded-md border border-dashed border-border bg-muted/30 px-3 py-4 text-center"
+        >
+          <p className="text-sm font-medium text-foreground">
+            {emptyState.activeFilters.length > 0
+              ? `No places match ${emptyState.activeFilters.join(" · ")}.`
+              : "No places are available in this view yet."}
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {emptyState.activeFilters.length > 0
+              ? "Clear a filter or suggest the place that is missing."
+              : "Know a useful place we should add? Suggest it to the maintainers."}
+          </p>
+          <div className="mt-3 flex flex-wrap justify-center gap-2">
+            {emptyState.activeFilters.length > 0 && (
+              <Button type="button" size="sm" variant="outline" onClick={emptyState.onReset}>
+                <RotateCcw className="size-3.5" />
+                Clear filters
+              </Button>
+            )}
+            <Button type="button" size="sm" onClick={emptyState.onSuggest}>
+              <MapPinPlus className="size-3.5" />
+              Suggest a place
+            </Button>
+          </div>
+        </div>
       ) : (
         <ul className="min-h-0 space-y-1 overflow-y-auto">
           {rows.map(({ place, distanceKm }) => (


### PR DESCRIPTION
Fixes #125

### What changed
- Explain active filters when a result list is empty and offer clear-filters and suggest-a-place actions.
- Add an accessible map loading state with a status label and visual skeleton.
- Clarify what remains available offline versus what needs a network connection.
- Add component coverage for the filtered empty state actions.

### Validation
- `node node_modules/eslint/bin/eslint.js`
- `node node_modules/vitest/vitest.mjs run` (38 tests passed)
- `node node_modules/typescript/bin/tsc --noEmit`
- `node node_modules/next/dist/bin/next build`
- `git diff --check`