### PR TITLE
fix(og): PNG fallback for non-city routes and robust font-weight parsing

### DIFF
--- a/src/app/city/[slug]/opengraph-image.tsx
+++ b/src/app/city/[slug]/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from "next/og";
 import { notFound } from "next/navigation";
 
-import { cityPages, cityPageSlugs } from "@/lib/city-pages";
+import { cityPageSlugs, findCityPage } from "@/lib/city-pages";
 import { getPlaces } from "@/lib/places";
 import { ogCitySummary } from "@/lib/og";
 
@@ -18,25 +18,21 @@ export function generateStaticParams(): { slug: string }[] {
   return cityPageSlugs(getPlaces());
 }
 
-// Next may pass a still-encoded segment (e.g. "%E5%8E%A6%E9%97%A8" for the
-// city 厦门), so decode before comparing against dataset slugs — mirrors the
-// city page's own decodeSlug.
-function decodeSlug(raw: string): string {
-  try {
-    return decodeURIComponent(raw);
-  } catch {
-    return raw;
-  }
-}
-
 // next/og runs on the edge runtime, where there is no system font to rely
 // on — fetch the brand typeface instead. Request the CSS with a legacy
 // user-agent so Google returns truetype URLs: the image renderer reads
-// ttf/otf, not woff2. The result is cached for the process lifetime (the
+// ttf/otf, not woff2. Each font carries the weight parsed from its own
+// @font-face block, so a changed block count or order can never silently
+// mislabel weights. The result is cached for the process lifetime (the
 // build, for these static pages).
-let headingFontPromise: Promise<ArrayBuffer[] | null> | null = null;
+interface HeadingFont {
+  data: ArrayBuffer;
+  weight: 400 | 700;
+}
 
-function loadHeadingFonts(): Promise<ArrayBuffer[] | null> {
+let headingFontPromise: Promise<HeadingFont[] | null> | null = null;
+
+function loadHeadingFonts(): Promise<HeadingFont[] | null> {
   if (!headingFontPromise) {
     headingFontPromise = (async () => {
       try {
@@ -44,16 +40,24 @@ function loadHeadingFonts(): Promise<ArrayBuffer[] | null> {
           "https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;700&display=swap",
           { headers: { "User-Agent": "Mozilla/4.0" } },
         ).then((response) => response.text());
-        const fonts: ArrayBuffer[] = [];
+        const byWeight = new Map<400 | 700, ArrayBuffer>();
         for (const block of css.matchAll(/@font-face\s*\{([^}]+)\}/g)) {
           const url = block[1].match(
             /url\((https:\/\/fonts\.gstatic\.com\/[^)]+\.ttf)\)/,
           )?.[1];
-          if (url) {
-            fonts.push(await fetch(url).then((response) => response.arrayBuffer()));
-          }
+          const weight = Number(
+            block[1].match(/font-weight:\s*(\d+)/)?.[1],
+          );
+          if (!url || (weight !== 400 && weight !== 700)) continue;
+          if (byWeight.has(weight)) continue;
+          byWeight.set(
+            weight,
+            await fetch(url).then((response) => response.arrayBuffer()),
+          );
         }
-        return fonts.length ? fonts : null;
+        return byWeight.size
+          ? Array.from(byWeight, ([weight, data]) => ({ data, weight }))
+          : null;
       } catch {
         // Unreachable font host must not fail the build: fall back to a
         // system stack rather than shipping no image at all.
@@ -70,17 +74,15 @@ interface CityOgImageProps {
 
 export default async function CityOgImage({ params }: CityOgImageProps) {
   const { slug } = await params;
-  const page = cityPages(getPlaces()).find(
-    (candidate) => candidate.slug === decodeSlug(slug),
-  );
+  const page = findCityPage(getPlaces(), slug);
   if (!page) notFound();
 
   const summary = ogCitySummary(page);
   const fontData = await loadHeadingFonts();
-  const fonts = (fontData ?? []).map((data, index) => ({
+  const fonts = (fontData ?? []).map(({ data, weight }) => ({
     data,
     name: "Space Grotesk",
-    weight: (index === 0 ? 400 : 700) as 400 | 700,
+    weight,
     style: "normal" as const,
   }));
   const fontFamily = fontData

--- a/src/app/city/[slug]/page.tsx
+++ b/src/app/city/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from "next/navigation";
 
 import {
   cityPageSlugs,
-  cityPages,
+  findCityPage,
   placesByType,
 } from "@/lib/city-pages";
 import { getPlaces } from "@/lib/places";
@@ -28,23 +28,11 @@ interface CityPageProps {
   params: Promise<{ slug: string }>;
 }
 
-// Next may pass a still-encoded segment (e.g. "%E5%8E%A6%E9%97%A8" for the
-// city 厦门), so decode before comparing against dataset slugs.
-function decodeSlug(raw: string): string {
-  try {
-    return decodeURIComponent(raw);
-  } catch {
-    return raw;
-  }
-}
-
 export async function generateMetadata({
   params,
 }: CityPageProps): Promise<Metadata> {
   const { slug } = await params;
-  const page = cityPages(getPlaces()).find(
-    (candidate) => candidate.slug === decodeSlug(slug),
-  );
+  const page = findCityPage(getPlaces(), slug);
   if (!page) return {};
   const name = humanizeCity(page.city);
   return {
@@ -55,9 +43,7 @@ export async function generateMetadata({
 
 export default async function CityPage({ params }: CityPageProps) {
   const { slug } = await params;
-  const page = cityPages(getPlaces()).find(
-    (candidate) => candidate.slug === decodeSlug(slug),
-  );
+  const page = findCityPage(getPlaces(), slug);
   if (!page) notFound();
 
   const name = humanizeCity(page.city);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,9 @@ export const metadata: Metadata = {
   openGraph: {
     title: site.name,
     description: site.tagline,
-    images: ["/brand/og.svg"],
+    // PNG, not SVG: crawlers (Facebook, X, WhatsApp, iMessage) refuse SVG
+    // og:image, so an SVG fallback never unfurls outside the site itself.
+    images: ["/brand/og.png"],
   },
   manifest: "/manifest.webmanifest",
   appleWebApp: {

--- a/src/lib/city-pages.ts
+++ b/src/lib/city-pages.ts
@@ -66,6 +66,26 @@ export function cityPageSlugs(places: Place[]): { slug: string }[] {
   return cityPages(places).map(({ slug }) => ({ slug }));
 }
 
+/**
+ * Find a city page by the raw slug Next hands a route (page or image file).
+ * The segment may still be percent-encoded (e.g. "%E5%8E%A6%E9%97%A8" for
+ * 厦门), so decode before comparing against dataset slugs; malformed
+ * sequences fall back to the raw value. Returns undefined — not an error —
+ * for slugs outside the dataset, leaving 404 policy to the caller.
+ */
+export function findCityPage(
+  places: Place[],
+  rawSlug: string,
+): CityPage | undefined {
+  let slug = rawSlug;
+  try {
+    slug = decodeURIComponent(rawSlug);
+  } catch {
+    // Keep the raw segment rather than throwing on malformed input.
+  }
+  return cityPages(places).find((candidate) => candidate.slug === slug);
+}
+
 /** A city's places grouped by type, in the canonical PLACE_TYPES order. */
 export function placesByType(places: Place[]): [PlaceType, Place[]][] {
   return (PLACE_TYPES.map(


### PR DESCRIPTION
Follow-up fixes from reviewing the #122 implementation (PR #138):

**Changes**

1. **Root OG fallback → PNG** (`src/app/layout.tsx:25`)
   - SVG `og:image` is rejected by Facebook, X, WhatsApp, iMessage — never unfurls outside the site.
   - Switched to existing `/brand/og.png` (924×540). A proper 1200×630 export can follow in a separate PR.

2. **Centralized city lookup** (`src/lib/city-pages.ts`, `src/app/city/[slug]/page.tsx`, `src/app/city/[slug]/opengraph-image.tsx`)
   - New `findCityPage(places, rawSlug)` helper handles percent-decoding + dataset lookup.
   - Eliminates duplicated `decodeSlug` + `cityPages().find()` in both the city page and its OG image route.

3. **Robust font-weight loading** (`src/app/city/[slug]/opengraph-image.tsx:39-71`)
   - Old code assumed Google's CSS returned exactly 2 TTF blocks in order [400, 700] and mapped by array index.
   - New code parses `font-weight:` from each `@font-face` block, carries weight with the font data, and dedupes by weight.
   - A changed block count/order can no longer silently mislabel weights (which caused bold text to render regular).

**Verification**
- ✅ 91/91 unit tests pass (incl. 4 `ogCitySummary` tests)
- ✅ ESLint clean on touched files
- ✅ `next build` succeeds: 217 distinct per-city 1200×630 PNGs prerendered
- ✅ `/about` now emits `og:image = /brand/og.png`; city pages emit their own image

**Note on fallback dimensions**
The existing `public/brand/og.png` is 924×540 (1.71:1) vs the OG standard 1200×630 (1.91:1). Facebook/X accept it but may crop slightly. A follow-up to regenerate at 1200×630 with brand fonts embedded would be ideal; this PR uses what's available to unblock unfurls today.

Closes the outstanding follow-ups from the review of #138 (which closed #122).
