### PR TITLE
Fix/map share state validation

### DIFF
--- a/src/lib/share.test.ts
+++ b/src/lib/share.test.ts
@@ -75,6 +75,30 @@ describe("mapStateToSearch / parseMapState round-trip", () => {
     expect(bogus.lng).toBeNull();
   });
 
+  it("rejects out-of-range viewport coordinates and zoom", () => {
+    expect(parseMapState("?lat=90&lng=180&zoom=20")).toMatchObject({
+      lat: 90,
+      lng: 180,
+      zoom: 20,
+    });
+
+    expect(parseMapState("?lat=91&lng=180&zoom=20")).toMatchObject({
+      lat: null,
+      lng: null,
+      zoom: null,
+    });
+    expect(parseMapState("?lat=-90&lng=-181&zoom=20")).toMatchObject({
+      lat: null,
+      lng: null,
+      zoom: null,
+    });
+    expect(parseMapState("?lat=0&lng=0&zoom=21")).toMatchObject({
+      lat: 0,
+      lng: 0,
+      zoom: null,
+    });
+  });
+
   it("omits the zoom when it is null", () => {
     const search = mapStateToSearch({ ...emptyState, lat: 19.076, lng: 72.8777 });
     expect(search).toBe("?lat=19.076&lng=72.8777");

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -21,19 +21,22 @@ function parseList(raw: string | null, allowed: Set<string>): string[] {
     .filter((value) => allowed.has(value));
 }
 
-function parseNumber(raw: string | null): number | null {
+function parseNumber(raw: string | null, min?: number, max?: number): number | null {
   if (raw === null || raw.trim() === "") return null;
   const value = Number(raw);
-  return Number.isFinite(value) ? value : null;
+  if (!Number.isFinite(value)) return null;
+  if (min !== undefined && value < min) return null;
+  if (max !== undefined && value > max) return null;
+  return value;
 }
 
 /** Read filter, focused-pin, and viewport state out of a URL query string. */
 export function parseMapState(search: string): MapShareState {
   const params = new URLSearchParams(search);
   const city = params.get("city")?.trim() || null;
-  const lat = parseNumber(params.get("lat"));
-  const lng = parseNumber(params.get("lng"));
-  const zoom = parseNumber(params.get("zoom"));
+  const lat = parseNumber(params.get("lat"), -90, 90);
+  const lng = parseNumber(params.get("lng"), -180, 180);
+  const zoom = parseNumber(params.get("zoom"), 0, 20);
   // A viewport only makes sense with both coordinates; otherwise ignore all three.
   const hasViewport = lat !== null && lng !== null;
   return {


### PR DESCRIPTION
## What this changes

Fixes #154 by validating shared map viewport parameters before they are passed to Leaflet.

Latitude, longitude, and zoom values are now constrained to valid ranges, with regression tests covering valid boundaries and invalid values.

## Type of change

- [ ] New public place(s)
- [ ] New or updated benefit guide
- [ ] New or updated resource link
- [x] Code or fix
- [ ] Docs

## Proof (required for new public places)

Fill this in for every place added in this PR. It stays in the PR, not in the
dataset.

| Field | Value |
|-------|-------|
| Source or citation | N/A |
| Google Maps rating (must be >= 4.0) | N/A |
| Google Maps review count (must be >= 50) | N/A |
| Date verified | N/A |

- [ ] Each place's rating is 4.0 or higher.
- [ ] Each place has 50 or more reviews.
- [ ] Coordinates point to the correct entrance.
- [ ] The JSON record stops at `gmaps_link` and `added_by` (no proof fields committed).

## Checklist

- [x] The site hosts no copyrighted files; resource and paper changes are links only.
- [x] No em dashes in any copy.