### PR TITLE
fix(offline): link back to map

### DIFF
--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -35,7 +35,7 @@ export default function OfflinePage() {
         </div>
       </div>
       <Button asChild className="mt-6">
-        <Link href="/">Back to the map</Link>
+        <Link href="/map">Back to the map</Link>
       </Button>
     </div>
   );


### PR DESCRIPTION
## What this changes

Fixes #165 by updating the "Back to the map" link on the offline page to correctly navigate to `/map` instead of `/`.

## Type of change

- [ ] New public place(s)
- [ ] New or updated benefit guide
- [ ] New or updated resource link
- [x] Code or fix
- [ ] Docs

## Proof (required for new public places)

Not applicable. This PR does not add or modify any public places.

## Checklist

- [x] The site hosts no copyrighted files; resource and paper changes are links only.
- [x] No em dashes in any copy.