### PR TITLE
fix(seo): correct city library pluralization

### DIFF
--- a/src/app/city/[slug]/page.tsx
+++ b/src/app/city/[slug]/page.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata({
   const name = humanizeCity(page.city);
   return {
     title: `${name} — student places`,
-    description: `Student-important places in ${name}: ${page.places.length} exam centre${page.places.length === 1 ? "" : "s"}, library${page.places.length === 1 ? "" : "ies"} and more, on the crowdsourced StudyMap.`,
+    description: `Student-important places in ${name}: ${page.places.length} exam centre${page.places.length === 1 ? "" : "s"}, ${page.places.length === 1 ? "library" : "libraries"} and more, on the crowdsourced StudyMap.`,
   };
 }
 


### PR DESCRIPTION
## What this changes

Fixes #158 by correcting the generated city-page meta description so plural library counts use "libraries" instead of "libraryies".

Single-library pages continue to use "library".

## Type of change

- [ ] New public place(s)
- [ ] New or updated benefit guide
- [ ] New or updated resource link
- [x] Code or fix
- [ ] Docs

## Proof (required for new public places)

Not applicable. This PR does not add or modify any public places.

## Checklist

- [x] The site hosts no copyrighted files; resource and paper changes are links only.
- [x] No em dashes in any copy.