### PR TITLE
fix(seo): add login page metadata

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,14 @@
+import type { Metadata } from "next";
 import { Suspense } from "react";
 import { LoginForm } from "./login-form";
+
+export const metadata: Metadata = {
+  title: "Sign in · StudyMap",
+  description: "Sign in to StudyMap to save places and manage your student map preferences.",
+  robots: {
+    index: false,
+  },
+};
 
 export default function LoginPage() {
   return (


### PR DESCRIPTION
## What this changes

Fixes #159 by adding dedicated metadata for the login page.

The page now has:
- A specific "Sign in · StudyMap" title
- A dedicated description
- A `noindex` robots directive

This prevents the login page from inheriting homepage metadata and provides defence in depth against indexing.

## Type of change

- [ ] New public place(s)
- [ ] New or updated benefit guide
- [ ] New or updated resource link
- [x] Code or fix
- [ ] Docs

## Proof (required for new public places)

Not applicable. This PR does not add or modify any public places.

## Checklist

- [x] The site hosts no copyrighted files; resource and paper changes are links only.
- [x] No em dashes in any copy.