### PR TITLE
fix(map): show preview attribution

### DIFF
--- a/src/components/home/map-preview.tsx
+++ b/src/components/home/map-preview.tsx
@@ -32,6 +32,27 @@ export function MapPreview({ places }: { places: Place[] }) {
         Live data, OpenStreetMap
       </div>
 
+      <div className="absolute bottom-2 left-2 z-[1001] rounded bg-background/90 px-1.5 py-0.5 text-[0.65rem] leading-tight text-muted-foreground shadow-sm">
+        <a
+          href="https://www.maptiler.com/copyright/"
+          target="_blank"
+          rel="noreferrer"
+          className="pointer-events-auto underline underline-offset-2"
+        >
+          MapTiler
+        </a>{" "}
+        <span aria-hidden="true">·</span>{" "}
+        <a
+          href="https://www.openstreetmap.org/copyright"
+          target="_blank"
+          rel="noreferrer"
+          className="pointer-events-auto underline underline-offset-2"
+        >
+          OpenStreetMap
+        </a>{" "}
+        contributors
+      </div>
+
       <Link
         href="/map"
         aria-label="Open the full interactive map"


### PR DESCRIPTION
## What this changes

Fixes #153 by displaying MapTiler and OpenStreetMap attribution on the landing-page map preview.

The attribution is visible in the preview and links to the respective copyright pages.

## Type of change

- [ ] New public place(s)
- [ ] New or updated benefit guide
- [ ] New or updated resource link
- [x] Code or fix
- [ ] Docs

## Proof (required for new public places)

Not applicable. This PR does not add or modify any public places.

## Checklist

- [x] The site hosts no copyrighted files; resource and paper changes are links only.
- [x] No em dashes in any copy.