### PR TITLE
fix(auth): handle Supabase auth check failures

### DIFF
--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -26,7 +26,7 @@ export function Navbar() {
   React.useEffect(() => {
     const supabase = createClient();
     if (!supabase) return;
-    supabase.auth.getUser().then(({ data }) => setLoggedIn(!!data.user));
+    supabase.auth.getUser().then(({ data }) => setLoggedIn(!!data.user)).catch(() => setLoggedIn(false));
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
       (_, session) => setLoggedIn(!!session),
     );

--- a/src/components/map/places-map.tsx
+++ b/src/components/map/places-map.tsx
@@ -127,7 +127,7 @@ export function PlacesMap({ places }: PlacesMapProps) {
   React.useEffect(() => {
     const supabase = createClient();
     if (!supabase) return; // self-host / preview mode: no auth, no private layer
-    supabase.auth.getUser().then(({ data }) => setUser(data.user));
+    supabase.auth.getUser().then(({ data }) => setUser(data.user)).catch(() => setUser(null));
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_, session) => setUser(session?.user ?? null));


### PR DESCRIPTION
## What this changes

Fixes #141 by handling rejected Supabase `getUser()` promises in the navbar and map.

When the auth request fails because of an offline visitor, expired session refresh, or Supabase outage, the UI now falls back to signed-out state instead of producing an unhandled promise rejection.

## Type of change

- [ ] New public place(s)
- [ ] New or updated benefit guide
- [ ] New or updated resource link
- [x] Code or fix
- [ ] Docs

## Proof (required for new public places)

Not applicable. This PR does not add or modify any public places.

## Checklist

- [x] The site hosts no copyrighted files; resource and paper changes are links only.
- [x] No em dashes in any copy.