### PR TITLE
fix(map): correct scroll zoom hint

### DIFF
--- a/src/components/map/map-view.tsx
+++ b/src/components/map/map-view.tsx
@@ -327,7 +327,7 @@ function ScrollZoomGuard() {
   return (
     <>
       <div className={`scroll-zoom-hint${hint ? " visible" : ""}`} aria-hidden>
-        Use Ctrl + scroll to zoom the map
+        Use Ctrl/Cmd + scroll to zoom the map
       </div>
       <span className="sr-only" role="note">
         Zoom the map with the + and - keys, or Ctrl/Cmd + scroll


### PR DESCRIPTION
## What this changes

Fixes #148 by updating the scroll-zoom hint to mention both Ctrl and Cmd.

The map already accepts both modifiers, so the visible instruction now matches the actual behavior for Windows, Linux, and macOS users.

## Type of change

- [ ] New public place(s)
- [ ] New or updated benefit guide
- [ ] New or updated resource link
- [x] Code or fix
- [ ] Docs

## Proof (required for new public places)

Not applicable. This PR does not add or modify any public places.

## Checklist

- [x] The site hosts no copyrighted files; resource and paper changes are links only.
- [x] No em dashes in any copy.