### PR TITLE
fix(map): remove stale place ids from shared urls

### DIFF
--- a/src/components/map/places-map.tsx
+++ b/src/components/map/places-map.tsx
@@ -61,7 +61,8 @@ export function PlacesMap({ places }: PlacesMapProps) {
   const [debouncedQuery, setDebouncedQuery] = React.useState("");
   const [focusId, setFocusId] = React.useState<string | null>(() => {
     if (typeof window === "undefined") return null;
-    return parseMapState(window.location.search).placeId ?? null;
+    const id = parseMapState(window.location.search).placeId ?? null;
+    return id && places.some((place) => place.id === id) ? id : null;
   });
   // A viewport in the URL restores that exact center/zoom on load instead of
   // fitting all places; it is then kept in sync as the user pans (see #118).


### PR DESCRIPTION
## What this changes

Fixes #149 by validating the place ID restored from the URL against the current place dataset.

If a shared link contains a deleted or renamed place ID, the map now drops that invalid focus instead of preserving a dead `?place=` parameter.

The existing URL synchronization then produces a clean shareable URL.

## Type of change

- [ ] New public place(s)
- [ ] New or updated benefit guide
- [ ] New or updated resource link
- [x] Code or fix
- [ ] Docs

## Proof (required for new public places)

Not applicable. This PR does not add or modify any public places.

## Checklist

- [x] The site hosts no copyrighted files; resource and paper changes are links only.
- [x] No em dashes in any copy.