### PR TITLE
fix(a11y): show focused result state

### DIFF
--- a/src/components/map/map-panel.tsx
+++ b/src/components/map/map-panel.tsx
@@ -52,6 +52,7 @@ interface MapPanelProps {
   onResetFilters: () => void;
   resultsToggle?: { label: string; onClick: () => void } | null;
   onSelectPlace: (place: Place) => void;
+  focusId?: string | null;
 
   onLocated: (loc: LatLng) => void;
   onShare: () => void;
@@ -82,6 +83,7 @@ export function MapPanel({
   onResetFilters,
   resultsToggle,
   onSelectPlace,
+  focusId,
   onLocated,
   onShare,
   myPlaces,
@@ -201,6 +203,7 @@ export function MapPanel({
           onSuggest: () => setSuggestOpen(true),
         }}
         onSelect={onSelectPlace}
+        focusId={focusId}
         toggle={resultsToggle}
       />
 

--- a/src/components/map/places-map.tsx
+++ b/src/components/map/places-map.tsx
@@ -320,6 +320,7 @@ export function PlacesMap({ places }: PlacesMapProps) {
     onResetFilters: () => setFilters({ types: [], city: null, query: "" }),
     resultsToggle,
     onSelectPlace: selectPlace,
+    focusId,
     onLocated,
     onShare: share,
     myPlaces: user

--- a/src/components/map/results-list.tsx
+++ b/src/components/map/results-list.tsx
@@ -24,6 +24,7 @@ interface ResultsListProps {
     onSuggest: () => void;
   };
   onSelect: (place: Place) => void;
+  focusId?: string | null;
   /** Optional expand/collapse control (e.g. "Show all" for the nearest list). */
   toggle?: { label: string; onClick: () => void } | null;
 }
@@ -34,6 +35,7 @@ export function ResultsList({
   rows,
   emptyState,
   onSelect,
+  focusId,
   toggle,
 }: ResultsListProps) {
   return (
@@ -81,44 +83,52 @@ export function ResultsList({
         </div>
       ) : (
         <ul className="min-h-0 space-y-1 overflow-y-auto">
-          {rows.map(({ place, distanceKm }) => (
-            <li key={place.id}>
-              <div className="group flex items-center gap-2.5 rounded-md px-2 py-2 hover:bg-muted">
-                <span
-                  aria-hidden
-                  className="size-3 shrink-0 rounded-full"
-                  style={{ backgroundColor: PLACE_TYPE_COLORS[place.type] }}
-                />
-                <button
-                  type="button"
-                  onClick={() => onSelect(place)}
-                  className="min-w-0 flex-1 text-left"
-                  title={`${place.name} (${PLACE_TYPE_LABELS[place.type]})`}
+          {rows.map(({ place, distanceKm }) => {
+            const focused = focusId === place.id;
+            return (
+              <li key={place.id}>
+                <div
+                  className={`group flex items-center gap-2.5 rounded-md px-2 py-2 ${
+                    focused ? "bg-muted ring-1 ring-border" : "hover:bg-muted"
+                  }`}
                 >
-                  <span className="flex items-center gap-1.5">
-                    <span className="block truncate text-sm text-foreground">
-                      {place.name}
+                  <span
+                    aria-hidden
+                    className="size-3 shrink-0 rounded-full"
+                    style={{ backgroundColor: PLACE_TYPE_COLORS[place.type] }}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => onSelect(place)}
+                    aria-current={focused ? "true" : undefined}
+                    className="min-w-0 flex-1 text-left"
+                    title={`${place.name} (${PLACE_TYPE_LABELS[place.type]})`}
+                  >
+                    <span className="flex items-center gap-1.5">
+                      <span className="block truncate text-sm text-foreground">
+                        {place.name}
+                      </span>
+                      <VerifiedBadge place={place} />
                     </span>
-                    <VerifiedBadge place={place} />
-                  </span>
-                  <span className="block truncate text-xs text-muted-foreground">
-                    {PLACE_TYPE_LABELS[place.type]}
-                    {distanceKm !== undefined && ` · ${formatDistance(distanceKm)}`}
-                  </span>
-                </button>
-                <a
-                  href={directionsUrl(place.lat, place.lng)}
-                  target="_blank"
-                  rel="noreferrer"
-                  onClick={(e) => e.stopPropagation()}
-                  aria-label={`Directions to ${place.name}`}
-                  className="shrink-0 rounded-md p-2 text-muted-foreground transition-colors hover:bg-background hover:text-foreground focus-visible:bg-background focus-visible:text-foreground"
-                >
-                  <Navigation className="size-4" />
-                </a>
-              </div>
-            </li>
-          ))}
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {PLACE_TYPE_LABELS[place.type]}
+                      {distanceKm !== undefined && ` · ${formatDistance(distanceKm)}`}
+                    </span>
+                  </button>
+                  <a
+                    href={directionsUrl(place.lat, place.lng)}
+                    target="_blank"
+                    rel="noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                    aria-label={`Directions to ${place.name}`}
+                    className="shrink-0 rounded-md p-2 text-muted-foreground transition-colors hover:bg-background hover:text-foreground focus-visible:bg-background focus-visible:text-foreground"
+                  >
+                    <Navigation className="size-4" />
+                  </a>
+                </div>
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/src/components/map/results-list.tsx
+++ b/src/components/map/results-list.tsx
@@ -83,52 +83,49 @@ export function ResultsList({
         </div>
       ) : (
         <ul className="min-h-0 space-y-1 overflow-y-auto">
-          {rows.map(({ place, distanceKm }) => {
-            const focused = focusId === place.id;
-            return (
-              <li key={place.id}>
-                <div
-                  className={`group flex items-center gap-2.5 rounded-md px-2 py-2 ${
-                    focused ? "bg-muted ring-1 ring-border" : "hover:bg-muted"
-                  }`}
+          {rows.map(({ place, distanceKm }) => (
+            <li key={place.id}>
+              <div
+                className={`group flex items-center gap-2.5 rounded-md px-2 py-2 ${
+                  focusId === place.id ? "bg-muted ring-1 ring-border" : "hover:bg-muted"
+                }`}
+              >
+                <span
+                  aria-hidden
+                  className="size-3 shrink-0 rounded-full"
+                  style={{ backgroundColor: PLACE_TYPE_COLORS[place.type] }}
+                />
+                <button
+                  type="button"
+                  onClick={() => onSelect(place)}
+                  aria-current={focusId === place.id ? "true" : undefined}
+                  className="min-w-0 flex-1 text-left"
+                  title={`${place.name} (${PLACE_TYPE_LABELS[place.type]})`}
                 >
-                  <span
-                    aria-hidden
-                    className="size-3 shrink-0 rounded-full"
-                    style={{ backgroundColor: PLACE_TYPE_COLORS[place.type] }}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => onSelect(place)}
-                    aria-current={focused ? "true" : undefined}
-                    className="min-w-0 flex-1 text-left"
-                    title={`${place.name} (${PLACE_TYPE_LABELS[place.type]})`}
-                  >
-                    <span className="flex items-center gap-1.5">
-                      <span className="block truncate text-sm text-foreground">
-                        {place.name}
-                      </span>
-                      <VerifiedBadge place={place} />
+                  <span className="flex items-center gap-1.5">
+                    <span className="block truncate text-sm text-foreground">
+                      {place.name}
                     </span>
-                    <span className="block truncate text-xs text-muted-foreground">
-                      {PLACE_TYPE_LABELS[place.type]}
-                      {distanceKm !== undefined && ` · ${formatDistance(distanceKm)}`}
-                    </span>
-                  </button>
-                  <a
-                    href={directionsUrl(place.lat, place.lng)}
-                    target="_blank"
-                    rel="noreferrer"
-                    onClick={(e) => e.stopPropagation()}
-                    aria-label={`Directions to ${place.name}`}
-                    className="shrink-0 rounded-md p-2 text-muted-foreground transition-colors hover:bg-background hover:text-foreground focus-visible:bg-background focus-visible:text-foreground"
-                  >
-                    <Navigation className="size-4" />
-                  </a>
-                </div>
-              </li>
-            );
-          })}
+                    <VerifiedBadge place={place} />
+                  </span>
+                  <span className="block truncate text-xs text-muted-foreground">
+                    {PLACE_TYPE_LABELS[place.type]}
+                    {distanceKm !== undefined && ` · ${formatDistance(distanceKm)}`}
+                  </span>
+                </button>
+                <a
+                  href={directionsUrl(place.lat, place.lng)}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={(e) => e.stopPropagation()}
+                  aria-label={`Directions to ${place.name}`}
+                  className="shrink-0 rounded-md p-2 text-muted-foreground transition-colors hover:bg-background hover:text-foreground focus-visible:bg-background focus-visible:text-foreground"
+                >
+                  <Navigation className="size-4" />
+                </a>
+              </div>
+            </li>
+          ))}
         </ul>
       )}
     </div>


### PR DESCRIPTION
## What this changes

Fixes #152 by exposing the currently focused place in the results list.

The focused result now has a visible selected state and exposes `aria-current="true"` so both visual users and screen-reader users can identify which result corresponds to the focused map pin.

The existing focus ID is passed through the map panel into the results list without changing the selection behavior.

## Type of change

- [ ] New public place(s)
- [ ] New or updated benefit guide
- [ ] New or updated resource link
- [x] Code or fix
- [ ] Docs

## Proof (required for new public places)

Not applicable. This PR does not add or modify any public places.

## Checklist

- [x] The site hosts no copyrighted files; resource and paper changes are links only.
- [x] No em dashes in any copy.