### PR TITLE
fix(auth): sanitize next redirects

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -2,6 +2,7 @@ import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 
+import { safeNext } from "@/lib/safe-next";
 import { isSupabaseConfigured } from "@/lib/supabase/config";
 
 // Always redirect to the canonical domain after OAuth so that arriving via
@@ -13,7 +14,7 @@ const SITE_URL =
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const code = searchParams.get("code");
-  const next = searchParams.get("next") ?? "/";
+  const next = safeNext(searchParams.get("next"));
 
   // No Supabase configured (self-host / preview mode): nothing to exchange.
   if (!isSupabaseConfigured()) {

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
 
 import { createClient } from "@/lib/supabase/client";
+import { safeNext } from "@/lib/safe-next";
 import { site } from "@/lib/site";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -15,7 +16,7 @@ import { Label } from "@/components/ui/label";
 export function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const next = searchParams.get("next") ?? "/";
+  const next = safeNext(searchParams.get("next"));
 
   const supabase = createClient();
 

--- a/src/lib/safe-next.test.ts
+++ b/src/lib/safe-next.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { safeNext } from "./safe-next";
+
+describe("safeNext", () => {
+  it.each([
+    [null, "/"],
+    ["", "/"],
+    ["/", "/"],
+    ["/map", "/map"],
+    ["/calendar?term=fall#today", "/calendar?term=fall#today"],
+  ])("maps %j to %j", (raw, expected) => {
+    expect(safeNext(raw)).toBe(expected);
+  });
+
+  it.each([
+    "https://evil.example",
+    "http://evil.example",
+    "//evil.example",
+    "///evil.example",
+    "/\\evil.example",
+    "/\tevil.example",
+    "/\nevil.example",
+    "\u0000/map",
+    "map",
+    "?next=/map",
+    "#map",
+  ])("rejects unsafe redirect %j", (raw) => {
+    expect(safeNext(raw)).toBe("/");
+  });
+});

--- a/src/lib/safe-next.ts
+++ b/src/lib/safe-next.ts
@@ -1,0 +1,16 @@
+const CONTROL_CHAR_RE = /[\u0000-\u001F\u007F]/;
+
+export function safeNext(raw: string | null): string {
+  if (!raw) return "/";
+
+  if (
+    !raw.startsWith("/") ||
+    raw.startsWith("//") ||
+    raw.includes("\\") ||
+    CONTROL_CHAR_RE.test(raw)
+  ) {
+    return "/";
+  }
+
+  return raw;
+}


### PR DESCRIPTION
Closes #161.

## What changed

- Adds a shared `safeNext` helper for authentication redirects.
- Accepts only root-relative same-origin paths.
- Rejects absolute URLs, protocol-relative URLs, backslashes and ASCII control characters.
- Uses the same sanitizer in both the email sign-in flow and OAuth callback.
- Preserves query strings and fragments on valid internal paths.
- Adds focused unit coverage for safe and unsafe redirect inputs.

Both redirect consumers now apply the same policy rather than relying on different client and server behaviour.

## Verification

Final commit:

`4ae07fb3d08a5ea42fc2164c00c74f58a2ed7467`

On the final source:

- `npm run build` passed
- `npm run lint` passed
- `npx tsc --noEmit` passed
- place-data validation passed

Unit validation used the same source plus a temporary CI-only test job:

- 12 test files passed
- 108 tests passed
- 16 `safeNext` cases passed

Validation PR:
https://github.com/AyobamiH/StudyMap/pull/4