### PR TITLE
fix(auth): show OAuth callback errors

### DIFF
--- a/src/app/login/login-form.test.tsx
+++ b/src/app/login/login-form.test.tsx
@@ -1,0 +1,67 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LoginForm } from "./login-form";
+
+const { searchParamsGet } = vi.hoisted(() => ({
+  searchParamsGet: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => ({ get: searchParamsGet }),
+}));
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({ auth: {} }),
+}));
+
+beforeEach(() => {
+  searchParamsGet.mockImplementation((name: string) =>
+    name === "error" ? "auth_error" : null,
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("LoginForm OAuth errors", () => {
+  it("shows the callback error in a dismissible alert", () => {
+    render(<LoginForm />);
+
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Sign-in failed or was cancelled. Please try again.",
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Dismiss sign-in error" }),
+    );
+
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("uses safe fallback copy for an unknown error code", () => {
+    searchParamsGet.mockImplementation((name: string) =>
+      name === "error" ? "__proto__" : null,
+    );
+
+    render(<LoginForm />);
+
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Sign-in failed. Please try again.",
+    );
+    expect(screen.getByRole("alert").textContent).not.toContain(
+      "__proto__",
+    );
+  });
+
+  it("does not show an alert without an error code", () => {
+    searchParamsGet.mockReturnValue(null);
+
+    render(<LoginForm />);
+
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
-import { Loader2 } from "lucide-react";
+import { Loader2, TriangleAlert, X } from "lucide-react";
 
 import { createClient } from "@/lib/supabase/client";
 import { safeNext } from "@/lib/safe-next";
@@ -13,10 +13,20 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
+const AUTH_ERROR_MESSAGES = new Map([
+  ["auth_error", "Sign-in failed or was cancelled. Please try again."],
+]);
+
+const DEFAULT_AUTH_ERROR_MESSAGE = "Sign-in failed. Please try again.";
+
 export function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const next = safeNext(searchParams.get("next"));
+  const errorCode = searchParams.get("error");
+  const errorMessage = errorCode
+    ? (AUTH_ERROR_MESSAGES.get(errorCode) ?? DEFAULT_AUTH_ERROR_MESSAGE)
+    : null;
 
   const supabase = createClient();
 
@@ -24,6 +34,9 @@ export function LoginForm() {
   const [email, setEmail] = React.useState("");
   const [password, setPassword] = React.useState("");
   const [loading, setLoading] = React.useState(false);
+  const [dismissedErrorCode, setDismissedErrorCode] = React.useState<string | null>(
+    null,
+  );
 
   // Self-host / preview mode: Supabase isn't configured, so there's no auth.
   if (!supabase) {
@@ -113,6 +126,24 @@ export function LoginForm() {
             {mode === "signin" ? "Sign in to continue" : "Create your account"}
           </p>
         </div>
+
+        {errorMessage && dismissedErrorCode !== errorCode && (
+          <div
+            role="alert"
+            className="flex items-start gap-3 rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+          >
+            <TriangleAlert className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+            <p className="flex-1">{errorMessage}</p>
+            <button
+              type="button"
+              aria-label="Dismiss sign-in error"
+              className="flex size-6 shrink-0 items-center justify-center rounded-sm opacity-70 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              onClick={() => setDismissedErrorCode(errorCode)}
+            >
+              <X className="size-4" aria-hidden="true" />
+            </button>
+          </div>
+        )}
 
         {/* Card */}
         <div className="rounded-xl border bg-card p-6 shadow-sm space-y-5">


### PR DESCRIPTION
Summary

* Show a dismissible alert when the OAuth callback returns an error
* Map the known auth_error code to clear, user-friendly copy
* Use a Map so every unknown URL value, including prototype property names such as __proto__, safely falls back to generic copy
* Add focused tests for rendering, dismissal, adversarial unknown-code handling, and the no-error state
* Give the dismiss control a 24px pointer target

Fixes #162.

Verification

* npx vitest run src/app/login/login-form.test.tsx (3 passed)
* npm run test:unit (131 passed)
* npm run lint
* npx tsc --noEmit
* npm run build
* git diff --check
* npm run dev reached ready successfully

The visible alert and dismissal behaviour are covered by the repository’s jsdom component tests.