### PR TITLE
fix(data): replace 13 literal lat,lng gmaps_links (#229)

### DIFF
--- a/data/places/sat_centre.json
+++ b/data/places/sat_centre.json
@@ -3652,7 +3652,7 @@
     "exam": "SAT",
     "valid_till": "2026-11-07"
   },
-    {
+  {
     "id": "57137",
     "name": "WELLINGTON COLLEGE",
     "type": "sat_centre",
@@ -3660,7 +3660,7 @@
     "lat": 51.3624135,
     "lng": -0.8080941,
     "address": "DUKE'S RIDE",
-    "gmaps_link": "https://maps.google.com/?q=lat,lng",
+    "gmaps_link": "https://maps.google.com/?q=51.3624135,-0.8080941",
     "added_by": "Shauryagangrade",
     "exam": "SAT",
     "valid_till": "2026-11-07"
@@ -3673,7 +3673,7 @@
     "lat": 52.9133979,
     "lng": 1.105435,
     "address": "GRESHAM'S SCHOOL",
-    "gmaps_link": "https://maps.google.com/?q=lat,lng",
+    "gmaps_link": "https://maps.google.com/?q=52.9133979,1.105435",
     "added_by": "Shauryagangrade",
     "exam": "SAT",
     "valid_till": "2026-11-07"
@@ -3686,7 +3686,7 @@
     "lat": 50.845905,
     "lng": -0.3026392,
     "address": "LANCING COLLEGE",
-    "gmaps_link": "https://maps.google.com/?q=lat,lng",
+    "gmaps_link": "https://maps.google.com/?q=50.845905,-0.3026392",
     "added_by": "Shauryagangrade",
     "exam": "SAT",
     "valid_till": "2026-11-07"
@@ -3699,7 +3699,7 @@
     "lat": 51.529308,
     "lng": -0.4505667,
     "address": "108 VINE LANE",
-    "gmaps_link": "https://maps.google.com/?q=lat,lng",
+    "gmaps_link": "https://maps.google.com/?q=51.529308,-0.4505667",
     "added_by": "Shauryagangrade",
     "exam": "SAT",
     "valid_till": "2026-11-07"
@@ -3712,7 +3712,7 @@
     "lat": 51.7809367,
     "lng": -0.0307223,
     "address": "COLLEGE ROAD",
-    "gmaps_link": "https://maps.google.com/?q=lat,lng",
+    "gmaps_link": "https://maps.google.com/?q=51.7809367,-0.0307223",
     "added_by": "Shauryagangrade",
     "exam": "SAT",
     "valid_till": "2026-11-07"
@@ -3725,7 +3725,7 @@
     "lat": 52.7343597,
     "lng": -2.739891,
     "address": "SHREWSBURY SCHOOL",
-    "gmaps_link": "https://maps.google.com/?q=lat,lng",
+    "gmaps_link": "https://maps.google.com/?q=52.7343597,-2.739891",
     "added_by": "Shauryagangrade",
     "exam": "SAT",
     "valid_till": "2026-11-07"
@@ -3738,7 +3738,7 @@
     "lat": 51.4545374,
     "lng": -2.6525262,
     "address": "32 COLLEGE ROAD CLIFTON",
-    "gmaps_link": "https://maps.google.com/?q=lat,lng",
+    "gmaps_link": "https://maps.google.com/?q=51.4545374,-2.6525262",
     "added_by": "Shauryagangrade",
     "exam": "SAT",
     "valid_till": "2026-11-07"
@@ -3751,7 +3751,7 @@
     "lat": 53.6055858,
     "lng": -2.9208933,
     "address": "SOUTHPORT ROAD",
-    "gmaps_link": "https://maps.google.com/?q=lat,lng",
+    "gmaps_link": "https://maps.google.com/?q=53.6055858,-2.9208933",
     "added_by": "Shauryagangrade",
     "exam": "SAT",
     "valid_till": "2026-11-07"
@@ -3764,7 +3764,7 @@
     "lat": 51.5567447,
     "lng": -0.2023618,
     "address": "FROGNAL",
-    "gmaps_link": "https://maps.google.com/?q=lat,lng",
+    "gmaps_link": "https://maps.google.com/?q=51.5567447,-0.2023618",
     "added_by": "Shauryagangrade",
     "exam": "SAT",
     "valid_till": "2026-11-07"
@@ -3777,7 +3777,7 @@
     "lat": 54.5126023,
     "lng": -6.0422466,
     "address": "25 CASTLE STREET",
-    "gmaps_link": "https://maps.google.com/?q=lat,lng",
+    "gmaps_link": "https://maps.google.com/?q=54.5126023,-6.0422466",
     "added_by": "Shauryagangrade",
     "exam": "SAT",
     "valid_till": "2026-11-07"
@@ -3790,7 +3790,7 @@
     "lat": 51.4087711,
     "lng": -3.488243,
     "address": "ST DONATS CASTLE",
-    "gmaps_link": "https://maps.google.com/?q=lat,lng",
+    "gmaps_link": "https://maps.google.com/?q=51.4087711,-3.488243",
     "added_by": "Shauryagangrade",
     "exam": "SAT",
     "valid_till": "2026-11-07"
@@ -3803,7 +3803,7 @@
     "lat": 57.1937119,
     "lng": -2.2042166,
     "address": "PITFODELS HOUSE",
-    "gmaps_link": "https://maps.google.com/?q=lat,lng",
+    "gmaps_link": "https://maps.google.com/?q=57.1937119,-2.2042166",
     "added_by": "Shauryagangrade",
     "exam": "SAT",
     "valid_till": "2026-11-07"
@@ -3816,7 +3816,7 @@
     "lat": 51.7431151,
     "lng": -2.2807025,
     "address": "BRISTOL ROAD",
-    "gmaps_link": "https://maps.google.com/?q=lat,lng",
+    "gmaps_link": "https://maps.google.com/?q=51.7431151,-2.2807025",
     "added_by": "Shauryagangrade",
     "exam": "SAT",
     "valid_till": "2026-11-07"

--- a/scripts/lib/data-validation.mjs
+++ b/scripts/lib/data-validation.mjs
@@ -6,6 +6,21 @@
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
+/**
+ * True when `value` is a Google Maps link whose `q=` parameter is still the raw
+ * `<lat>,<lng>` placeholder from the record-shape template (see #229).
+ */
+export function isLatLngPlaceholderGmapsLink(value) {
+  if (typeof value !== "string") return false;
+  try {
+    const { searchParams } = new URL(value);
+    const q = searchParams.get("q");
+    return typeof q === "string" && q.trim() === "lat,lng";
+  } catch {
+    return false;
+  }
+}
+
 /** True when `value` is a "YYYY-MM-DD" string naming a real calendar date. */
 export function isRealIsoDate(value) {
   if (typeof value !== "string" || !ISO_DATE_RE.test(value)) return false;

--- a/scripts/validate-places.mjs
+++ b/scripts/validate-places.mjs
@@ -26,7 +26,12 @@
 import { readFileSync, readdirSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import { Reporter, hasEmDash, isRealIsoDate } from "./lib/data-validation.mjs";
+import {
+  Reporter,
+  hasEmDash,
+  isLatLngPlaceholderGmapsLink,
+  isRealIsoDate,
+} from "./lib/data-validation.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DATA_DIR = join(__dirname, "../data/places");
@@ -198,11 +203,18 @@ for (const file of files) {
     }
 
     // gmaps_link format
-    if (r.gmaps_link !== undefined && !GMAPS_RE.test(r.gmaps_link)) {
-      err(
-        loc,
-        `gmaps_link must be https://maps.google.com/?q=<lat>,<lng>, got "${r.gmaps_link}"`,
-      );
+    if (r.gmaps_link !== undefined) {
+      if (!GMAPS_RE.test(r.gmaps_link)) {
+        err(
+          loc,
+          `gmaps_link must be https://maps.google.com/?q=<lat>,<lng>, got "${r.gmaps_link}"`,
+        );
+      } else if (isLatLngPlaceholderGmapsLink(r.gmaps_link)) {
+        err(
+          loc,
+          `gmaps_link is still the literal "lat,lng" placeholder (see #229) — fill it with the record's coordinates`,
+        );
+      }
     }
 
     // No em dashes in any string field


### PR DESCRIPTION
## Summary
- Replaces the 13 literal `gmaps_link: "https://maps.google.com/?q=lat,lng"` placeholders in `sat_centre.json` with each record's own coordinates.
- Adds a validation check so a `gmaps_link` still containing the raw `lat,lng` placeholder now fails `npm run validate:places`, instead of silently passing the URL-pattern check.

Fixes #229

## Validation
- `npm run validate:places` passes with 0 errors and 0 warnings on the affected file.

## Notes
- The in-repo helper script `scripts/fix-229-latlng-gmaps.mjs` was used to do the replacement deterministically from the existing `lat`/`lng` values. It is a one-off fix script, not a long-lived tool, so I have not added it to the repo yet.

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>
