### PR TITLE
fix: audit and replace pixelated competition logos (#226)

### DIFF
--- a/scripts/audit-competition-logos.mjs
+++ b/scripts/audit-competition-logos.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/** Audit competition logos for #226 using sharp.
+
+This script reads every PNG in `public/competitions/`, extracts its pixel
+dimensions, and reports how many are under ~128px on their long edge. It uses
+`sharp` since the repo already depends on it and it parses local files without
+hitting the network.
+*/
+
+import { readFileSync, readdirSync } from "node:fs";
+import sharp from "sharp";
+
+const base = "public/competitions";
+const files = readdirSync(base);
+const rows = [];
+
+for (const name of files) {
+  if (!name.endsWith(".png")) continue;
+  const buf = readFileSync(`${base}/${name}`);
+  const { width, height } = await sharp(buf).metadata();
+  const w = width ?? -1;
+  const h = height ?? -1;
+  rows.push({
+    name,
+    w,
+    h,
+    bytes: buf.length,
+    small: Math.min(w, h) < 128,
+  });
+}
+
+rows.sort((a, b) => Math.min(a.w, a.h) - Math.min(b.w, b.h));
+
+let smallCount = 0;
+for (const r of rows) {
+  if (r.small) smallCount++;
+  console.log(
+    `${r.name.padEnd(52)} ${String(r.w).padStart(5)}x${String(r.h).padStart(5)}  ${r.bytes}B` +
+      (r.small ? "  <-- under ~128 long edge" : ""),
+  );
+}
+
+console.log("");
+console.log(`total pngs: ${rows.length}; under ~128 long edge: ${smallCount}`);


### PR DESCRIPTION
## Summary
- Adds `scripts/audit-competition-logos.mjs`, which reports the pixel dimensions of every PNG in `public/competitions/` and flags the ones under ~128px on the long edge.
- Repo's existing `sharp` dependency is used to parse the files locally, so the audit does not hit the network.
- This PR ships the audit first; the actual per-file logo replacements will come in the next commits on this branch once the small logos have been sourced and swapped in.

Fixes #226

## Current inventory
- 100 PNGs total in `public/competitions/`
- 80 of them are under ~128px on the long edge and are the pixelation problem described in #226.

Smallest logos (longest edge under ~128px):

16x16
- acsl.png
- bennington-young-writers-awards.png
- elks-mvs.png
- envirothon.png
- first-robotics-competition.png
- first-tech-challenge.png
- gates-scholarship.png
- hmmt.png
- ijso.png
- national-history-bee.png
- national-history-bowl.png
- new-york-fed-s-high-school-economics-essay.png
- nsda-national-tournament.png
- oxford-german-olympiad.png
- princeton-prize-in-race-relations.png
- river-of-words.png
- science-olympiad.png
- stock-market-game.png
- tournament-of-the-towns.png

32x32
- adroit-prize.png
- bpa-national-leadership-conference.png
- cineyouth.png
- concord-review.png
- congressional-art-competition.png
- cyberpatriot.png
- davidson-fellows-scholarship.png
- deca-icdc.png
- directing-change-ca.png
- european-physics-olympiad.png
- european-youth-parliament.png
- fbla-national-leadership-conference.png
- first-global-challenge.png
- foyle-young-poets-of-the-year-award.png
- igem-high-school.png
- international-biology-olympiad.png
- international-geography-olympiad.png
- international-history-olympiad.png
- international-linguistics-olympiad.png
- jshs.png
- math-prize-for-girls.png
- mathcounts.png
- mathworks-m3-challenge.png
- national-economics-challenge.png
- national-history-day.png
- national-personal-finance-challenge.png
- nfte-world-series-of-innovation.png
- questbridge-national-college-match.png
- rattle-poetry-prize.png
- regeneron-isef.png
- regeneron-science-talent-search.png
- scholastic-art-and-writing-awards.png
- signet-classics-student-scholarship-essay-contest.png
- the-politic-high-school-essay-competition.png
- usamo.png
- we-the-students-essay-contest.png
- widpsc.png
- world-robot-olympiad.png
- world-schools-debating-championship.png
- youngarts-national-arts-competition.png

48x48
- arml.png
- ayin-rand-institute-essay-contests.png
- doodle-for-google.png
- ecybermission.png
- international-earth-science-olympiad.png
- international-olympiad-in-informatics.png
- ioaa.png
- picoctf.png
- purple-comet-math-meet.png
- wharton-global-high-school-investment-competition.png
- wharton-high-school-data-science-competition.png

60x60
- meta-hacker-cup.png

64x64
- world-scholars-cup.png

68x67
- diamond-challenge.png

100x100 / 100x102 / 100x108 / 100x125
- all-american-high-school-film-festival.png
- bebras-challenge.png
- c-span-studentcam.png
- harvard-crimson-global-essay-competition.png
- harvard-model-united-nations.png
- ja-company-of-the-year.png
- nffty.png

Already acceptable (long edge at or above ~128px)
- jfk-profile-in-courage-essay-contest.png — 128x128
- usaco.png — 900x130
- international-physics-olympiad.png — 140x133
- write-the-world-competitions.png — 145x145
- bow-seat-ocean-awareness-contest.png — 150x150
- conrad-challenge.png — 150x150
- international-brain-bee.png — 150x150
- international-olympiad-in-ai.png — 150x150
- technovation-girls.png — 150x150
- international-biogeneius-challenge.png — 192x192
- john-locke-global-essay-prize.png — 192x192
- nasa-space-apps-challenge.png — 192x192
- national-latin-exam.png — 192x192
- international-mathematical-olympiad.png — 256x256
- mit-think.png — 256x256
- toyota-dream-car-art-contest.png — 256x256
- international-philosophy-olympiad.png — 600x338
- coca-cola-scholars.png — 360x360
- international-chemistry-olympiad.png — 610x470
- genius-olympiad.png — 1035x691

## Closing criteria
- No competition logo in `public/competitions/` is under ~128px on its long edge.
- `npm run validate:competitions` passes.
- Run `node scripts/audit-competition-logos.mjs` locally and confirm the "under ~128 long edge" count is 0 before merging.

## Notes
- The 80 under-size logos are mostly favicon-scale files; the real logos need to come from each organizer's site, press kit, or a large touch icon where one exists. I am not inventing source images here.
- Any competition that still has no decent source logo after searching should stay pegged in the PR body as a manual follow-up rather than replaced with a placeholder.

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>
