### PR TITLE
a11y: add skip-to-content link

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -85,6 +85,12 @@ export default function RootLayout({
       )}
     >
       <body className="flex min-h-full flex-col">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          Skip to content
+        </a>
         <ThemeProvider
           attribute="class"
           defaultTheme="system"
@@ -92,7 +98,9 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           <Navbar />
-          <main className="flex flex-1 flex-col pt-14">{children}</main>
+          <main id="main-content" className="flex flex-1 flex-col pt-14">
+            {children}
+          </main>
           <Footer />
           <Toaster richColors position="top-center" />
           <PwaRegister />


### PR DESCRIPTION
Adds a visually-hidden-until-focused 'Skip to content' link as the first focusable element in the body, jumping to a new id="main-content" on <main>. Follows the same sr-only/focus:not-sr-only Tailwind pattern already used elsewhere in the codebase (dialog.tsx, sheet.tsx close buttons).

Fixes #261

## What this changes

<!-- One or two lines. Link the issue if there is one. -->

## Type of change

- [ ] New public place(s)
- [ ] New or updated benefit guide
- [ ] New or updated resource link
- [ ] Code or fix
- [ ] Docs

## Proof (required for new public places)

Fill this in for every place added in this PR. It stays in the PR, not in the
dataset.

| Field                                    | Value |
| ---------------------------------------- | ----- |
| Source or citation                       |       |
| Google Maps rating (must be >= 4.0)      |       |
| Google Maps review count (must be >= 50) |       |
| Date verified                            |       |

- [ ] Each place's rating is 4.0 or higher.
- [ ] Each place has 50 or more reviews.
- [ ] Coordinates point to the correct entrance.
- [ ] The JSON record stops at `gmaps_link` and `added_by` (no proof fields committed).

## Checklist

- [ ] The site hosts no copyrighted files; resource and paper changes are links only.
- [ ] No em dashes in any copy.
