### PR TITLE
chore: add security headers to next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,29 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  // Basic hardening headers on every route. A full Content-Security-Policy
+  // is a bigger, separate effort (it would need to account for MapTiler
+  // tiles, Supabase, Vercel Analytics, and the Leaflet/OG image pipelines)
+  // and is left for a follow-up.
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          // geolocation stays enabled for this origin - the "Near me"
+          // feature genuinely uses it. Everything else this app doesn't
+          // use is disabled.
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=(self)",
+          },
+          // Nothing in the app needs to be iframed.
+          { key: "X-Frame-Options", value: "DENY" },
+        ],
+      },
+    ];
+  },
+};
 
 module.exports = nextConfig;


### PR DESCRIPTION
Adds X-Content-Type-Options, Referrer-Policy, Permissions-Policy, and X-Frame-Options across all routes. geolocation stays enabled for this origin (the 'Near me' feature genuinely uses it); camera/microphone are disabled since nothing here uses them. A full CSP is a bigger, separate effort (MapTiler, Supabase, Vercel Analytics, Leaflet/OG pipelines) and is left for a follow-up, as the issue itself scopes it.

Note on verification: couldn't run 'npm run build' + curl -I in this environment - the build fails on fetching Google Fonts regardless of this change (confirmed identically on unmodified main, unrelated network restriction in this sandbox). Verified the headers() function directly instead (node -e requiring next.config.js and awaiting headers()) - returns exactly the four rules above. Worth a real curl -I check against a local next start before merging.

Fixes #254

## What this changes

<!-- One or two lines. Link the issue if there is one. -->

## Type of change

- [ ] New public place(s)
- [ ] New or updated benefit guide
- [ ] New or updated resource link
- [ ] Code or fix
- [ ] Docs

## Proof (required for new public places)

Fill this in for every place added in this PR. It stays in the PR, not in the
dataset.

| Field                                    | Value |
| ---------------------------------------- | ----- |
| Source or citation                       |       |
| Google Maps rating (must be >= 4.0)      |       |
| Google Maps review count (must be >= 50) |       |
| Date verified                            |       |

- [ ] Each place's rating is 4.0 or higher.
- [ ] Each place has 50 or more reviews.
- [ ] Coordinates point to the correct entrance.
- [ ] The JSON record stops at `gmaps_link` and `added_by` (no proof fields committed).

## Checklist

- [ ] The site hosts no copyrighted files; resource and paper changes are links only.
- [ ] No em dashes in any copy.
