### PR TITLE
fix: use existing labels in issue templates (fixes #249)

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-competition.yml
+++ b/.github/ISSUE_TEMPLATE/add-competition.yml
@@ -1,7 +1,7 @@
 name: Add a competition
 description: Suggest a student competition for the catalog. A citation and a quality check are required.
 title: "[competition] "
-labels: ["competition"]
+labels: ["data", "competitions"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/add-place.yml
+++ b/.github/ISSUE_TEMPLATE/add-place.yml
@@ -1,7 +1,7 @@
 name: Add a public place
 description: Suggest a student place for the map. A citation and a quality check are required.
 title: "[place] "
-labels: ["place"]
+labels: ["data"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/verify-place.yml
+++ b/.github/ISSUE_TEMPLATE/verify-place.yml
@@ -1,7 +1,7 @@
 name: Verify a place
 description: Re-check an existing place on the map (address, entrance, open status). A smaller ask than adding a new place.
 title: "[verify] "
-labels: ["verification"]
+labels: ["data"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Fixes #249

Three issue templates referenced labels that don't exist in the repo. GitHub silently drops non-existent labels, so every place suggestion, competition suggestion, and verification request landed with no label at all.

Changes:
- `add-place.yml`: `"place"` → `"data"`
- `add-competition.yml`: `"competition"` → `"data", "competitions"`
- `verify-place.yml`: `"verification"` → `"data"`